### PR TITLE
Sort by date

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -95,16 +95,18 @@ body{
 	background-color: #c7f5d5;
 }
 
-button{	
+button{
 	outline: none;	
 	font-family: arial;
 	font-weight: 500;
 	font-size: 0.8em;
-	margin-top:3.5em;
-	margin-left:2em;
 	padding: 0.5em 2em;
 	border-radius: 2em;
 	font-weight: 500;
+}
+.flex-sidebar-item button{	
+	margin-top:3.5em;
+	margin-left:2em;
 }
 button.default-button{	
 	border: 1px solid rgba(0, 0, 0, 0.1);
@@ -190,9 +192,13 @@ button:hover{
 }
 
 /* Stats bar */
-.statistics-bar{
+.status-bar{
 	display: flex;
 	flex-direction: row;
+	justify-content: flex-start;
 	margin-left: 3em;
 	margin-top: 0.5em;
+}
+.status-bar > div{
+	align-self: flex-end;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -200,5 +200,26 @@ button:hover{
 	margin-top: 0.5em;
 }
 .status-bar > div{
-	align-self: flex-end;
+	margin: 0em 1em;
+	min-width: 10em;
+	flex: 1;
+	/*make this flex again for its children */
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-end;
+	align-items: center;
+}
+.status-bar select, .status-bar label{
+	font-size: 0.8em;
+	margin: 0em 0em 0em 1em;
+}
+.status-bar select{
+	border-radius: 2em;
+	background-color: rgba(255, 255, 255, 0.1);
+	box-shadow: inset -1px 1px 5px 1px rgba(0, 0, 0, 0.1);
+	min-height: 1.5em;
+	padding: 0em 1em 0em 0.5em;
+}
+.status-bar select:focus{
+	outline: none;
 }

--- a/index.html
+++ b/index.html
@@ -50,11 +50,11 @@
 		    			<div class="flex-item-list">
 		    				<!-- <h2>to do:</h2> -->
 		    				<div class="status-bar">
-		    					<tag-item id="total-items-tag" text="Total" data="0"></tag-item>
-		    					<tag-item id="active-items-tag" text="Active" data="0"></tag-item>
+		    					<tag-item id="total-items-tag" text="All" data="0"></tag-item>
+		    					<tag-item id="active-items-tag" text="Incomplete" data="0"></tag-item>
 								<tag-item id="completed-items-tag" text="Completed" data="0"></tag-item>
 								<div class="sort-criteria">
-									<label for="#sort-by">Sort By</label>
+									<label for="sort-by">Sort By</label>
 									<select id="sort-by">
 										<option value="by-date-desc">Latest First</option>
 										<option value="by-date-asc">Oldest First</option>										
@@ -63,23 +63,24 @@
 										<option value="by-status-complete-first">Status (Complete First)</option>
 										<option value="by-status-incomplete-first">Status (Incomplete First)</option>
 									</select>
-									<label for="#group-by">Group By</label>
-									<select id="sort-by">
-										<option>Status</option>
-										<option>Date</option>
-										<option>Priority</option>
+									<label for="group-by">Group By</label>
+									<select id="group-by">
+										<option value="by-none"></option>
+										<option value="by-status">Status</option>
+										<option value="by-date">Date</option>
+										<option value="by-priority">Priority</option>
 									</select>
 								</div>
 		    				</div>
-				    		<ul id="todo-list">
-				    			
-				    		</ul>
+				    		<div id="list-area">
+
+							</div>
 		    			</div>
 		    			<!-- <div class="flex-item-list divider"></div> -->
-		    			<div class="flex-item-list">
+		    			<!-- <div class="flex-item-list">
 		    				<ul id="completed-list">
 				    		</ul>
-		    			</div>    			
+		    			</div>    			 -->
 		    		</div>
 		    	</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -54,8 +54,19 @@
 		    					<tag-item id="active-items-tag" text="Active" data="0"></tag-item>
 								<tag-item id="completed-items-tag" text="Completed" data="0"></tag-item>
 								<div class="sort-criteria">
-									<input type="radio" name="sort-criteria" id="by-date"></input>
-									<label for="#by-date">By Date</label>
+									<label for="#sort-by">Sort By</label>
+									<select id="sort-by">
+										<option>None</option>
+										<option>Date</option>
+										<option>Priority</option>
+										<option>Status</option>
+									</select>
+									<label for="#group-by">Group By</label>
+									<select id="sort-by">
+										<option>Status</option>
+										<option>Date</option>
+										<option>Priority</option>
+									</select>
 								</div>
 		    				</div>
 				    		<ul id="todo-list">

--- a/index.html
+++ b/index.html
@@ -56,12 +56,12 @@
 								<div class="sort-criteria">
 									<label for="#sort-by">Sort By</label>
 									<select id="sort-by">
-										<option>Latest First</option>
-										<option>Oldest First</option>										
-										<option>Priority High to Low</option>
-										<option>Priority Low to High</option>
-										<option>Status (Complete First)</option>
-										<option>Status (Incomplete First)</option>
+										<option value="by-date-desc">Latest First</option>
+										<option value="by-date-asc">Oldest First</option>										
+										<option value="by-priority-desc">Priority High to Low</option>
+										<option value="by-priority-asc">Priority Low to High</option>
+										<option value="by-status-complete-first">Status (Complete First)</option>
+										<option value="by-status-incomplete-first">Status (Incomplete First)</option>
 									</select>
 									<label for="#group-by">Group By</label>
 									<select id="sort-by">

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 		    					<tag-item id="active-items-tag" text="Incomplete" data="0"></tag-item>
 								<tag-item id="completed-items-tag" text="Completed" data="0"></tag-item>
 								<div class="sort-criteria">
-									<label for="sort-by">Sort By</label>
+									<label for="sort-by" tooltip="Sorting is in-group">Sort By</label>
 									<select id="sort-by">
 										<option value="by-date-desc" selected>Latest First</option>
 										<option value="by-date-asc">Oldest First</option>										
@@ -73,14 +73,8 @@
 								</div>
 		    				</div>
 				    		<div id="list-area">
-
 							</div>
 		    			</div>
-		    			<!-- <div class="flex-item-list divider"></div> -->
-		    			<!-- <div class="flex-item-list">
-		    				<ul id="completed-list">
-				    		</ul>
-		    			</div>    			 -->
 		    		</div>
 		    	</div>
 			</div>
@@ -101,7 +95,8 @@
     	</div>
     </div>
     <!-- Optional JavaScript -->
-    <script src="js/jquery.js"></script>
+	<script src="js/jquery.js"></script>
+	<script src="js/util.js"></script>
     <script src="js/database.js"></script>
     <script src="js/model.js"></script>
     <script src="js/view.js"></script>

--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
 		    					<tag-item id="active-items-tag" text="Incomplete" data="0"></tag-item>
 								<tag-item id="completed-items-tag" text="Completed" data="0"></tag-item>
 								<div class="sort-criteria">
-									<label for="sort-by" tooltip="Sorting is in-group">Sort By</label>
-									<select id="sort-by">
+									<label for="sort-by" title="Sorting is in-group">Sort By</label>
+									<select id="sort-by" title="Sorting is in-group" >
 										<option value="by-date-desc" selected>Latest First</option>
 										<option value="by-date-asc">Oldest First</option>										
 										<option value="by-priority-desc">Priority High to Low</option>
@@ -63,8 +63,8 @@
 										<!-- <option value="by-status-complete-first">Status (Complete First)</option>
 										<option value="by-status-incomplete-first">Status (Incomplete First)</option> -->
 									</select>
-									<label for="group-by">Group By</label>
-									<select id="group-by">										
+									<label for="group-by" title="Gives best result if gouping and sorting are by same criteria">Group By</label>
+									<select id="group-by" title="Gives best result if gouping and sorting are by same criteria">										
 										<option value="by-status" selected>Status</option>
 										<option value="by-date">Date</option>
 										<option value="by-priority">Priority</option>

--- a/index.html
+++ b/index.html
@@ -49,10 +49,14 @@
 		    		<div class="flex-container-lists">
 		    			<div class="flex-item-list">
 		    				<!-- <h2>to do:</h2> -->
-		    				<div class="statistics-bar">
+		    				<div class="status-bar">
 		    					<tag-item id="total-items-tag" text="Total" data="0"></tag-item>
 		    					<tag-item id="active-items-tag" text="Active" data="0"></tag-item>
-		    					<tag-item id="completed-items-tag" text="Completed" data="0"></tag-item>
+								<tag-item id="completed-items-tag" text="Completed" data="0"></tag-item>
+								<div class="sort-criteria">
+									<input type="radio" name"sort-criteria" id="by-date"></input>
+									<label for="#by-date">By Date</label>
+								</div>
 		    				</div>
 				    		<ul id="todo-list">
 				    			

--- a/index.html
+++ b/index.html
@@ -56,19 +56,19 @@
 								<div class="sort-criteria">
 									<label for="sort-by">Sort By</label>
 									<select id="sort-by">
-										<option value="by-date-desc">Latest First</option>
+										<option value="by-date-desc" selected>Latest First</option>
 										<option value="by-date-asc">Oldest First</option>										
 										<option value="by-priority-desc">Priority High to Low</option>
 										<option value="by-priority-asc">Priority Low to High</option>
-										<option value="by-status-complete-first">Status (Complete First)</option>
-										<option value="by-status-incomplete-first">Status (Incomplete First)</option>
+										<!-- <option value="by-status-complete-first">Status (Complete First)</option>
+										<option value="by-status-incomplete-first">Status (Incomplete First)</option> -->
 									</select>
 									<label for="group-by">Group By</label>
-									<select id="group-by">
-										<option value="by-none"></option>
-										<option value="by-status">Status</option>
+									<select id="group-by">										
+										<option value="by-status" selected>Status</option>
 										<option value="by-date">Date</option>
 										<option value="by-priority">Priority</option>
+										<option value="by-none"></option>
 									</select>
 								</div>
 		    				</div>

--- a/index.html
+++ b/index.html
@@ -56,10 +56,12 @@
 								<div class="sort-criteria">
 									<label for="#sort-by">Sort By</label>
 									<select id="sort-by">
-										<option>None</option>
-										<option>Date</option>
-										<option>Priority</option>
-										<option>Status</option>
+										<option>Latest First</option>
+										<option>Oldest First</option>										
+										<option>Priority High to Low</option>
+										<option>Priority Low to High</option>
+										<option>Status (Complete First)</option>
+										<option>Status (Incomplete First)</option>
 									</select>
 									<label for="#group-by">Group By</label>
 									<select id="sort-by">

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 		    					<tag-item id="active-items-tag" text="Active" data="0"></tag-item>
 								<tag-item id="completed-items-tag" text="Completed" data="0"></tag-item>
 								<div class="sort-criteria">
-									<input type="radio" name"sort-criteria" id="by-date"></input>
+									<input type="radio" name="sort-criteria" id="by-date"></input>
 									<label for="#by-date">By Date</label>
 								</div>
 		    				</div>

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,9 @@
 var App = function(){
 	this.model = new Model();
-	this.view  = new View();
-	this.controller = new Controller(this.model, this.view);
+	this.model.init();
+	this.view  = new View(this.model);
+	this.view.init();
+	// this.controller = new Controller(this.model, this.view);
 
-	this.controller.init();
+	// this.controller.init();
 };

--- a/js/controller.js
+++ b/js/controller.js
@@ -1,37 +1,37 @@
-let Controller = function(model, view){
+// let Controller = function(model, view){
 
-	this.model = model;
-	this.view  = view;
+// 	this.model = model;
+// 	this.view  = view;
 	
-	this.init = function(){
-		this.model.init();
-		this.view.init(this);
-		this.view.refreshList();
-	};
+// 	this.init = function(){
+// 		this.model.init();
+// 		this.view.init(this);
+// 		this.view.refreshList();
+// 	};
 
-	this.getAllItems = function(){
-		return this.model.getList();
-	};
+// 	this.getAllItems = function(){
+// 		return this.model.getList();
+// 	};
 	
-	this.loadAllItems = function(){
-		return this.model.loadAllItems();
-	};
+// 	this.loadAllItems = function(){
+// 		return this.model.loadAllItems();
+// 	};
 	
-	this.addItem = function(todoItem){
-		return this.model.addItem(todoItem);
-	};
+// 	this.addItem = function(todoItem){
+// 		return this.model.addItem(todoItem);
+// 	};
 
-	this.clearCompleted = function(){
-		return this.model.clearCompleted();
-	};
+// 	this.clearCompleted = function(){
+// 		return this.model.clearCompleted();
+// 	};
 	
-	this.clearAll = function(){ return this.model.clearAll(); };
+// 	this.clearAll = function(){ return this.model.clearAll(); };
 	
-	this.updateStatus = function($item){
-		return this.model.updateStatus($item);
-	};
+// 	this.updateStatus = function($item){
+// 		return this.model.updateStatus($item);
+// 	};
 
-	this.deleteSingleItem = function(item){
-		return this.model.deleteSingleItem(item);
-	};
-};
+// 	this.deleteSingleItem = function(item){
+// 		return this.model.deleteSingleItem(item);
+// 	};
+// };

--- a/js/model.js
+++ b/js/model.js
@@ -61,8 +61,7 @@ let Model = function(){
 	this.clearAll = function(){ return this.db.deleteAll(); }; //returns a promise
 
 	this.updateStatus = function($item){
-		return this.db.updateStatus($($item).attr('id'), 
-									$($item).attr('status')); //returns a promise
+		return this.db.updateStatus($($item).attr('id'), $($item).attr('status')); //returns a promise
 	};
 
 	this.deleteSingleItem = function(item){

--- a/js/model.js
+++ b/js/model.js
@@ -44,6 +44,7 @@ let Model = function(){
 	async function loadAllItems(){
 		let results = await this.db.loadAllItems(); // returns a promise
 		self.taskList = Object.values(results.rows);
+		self.taskList.forEach( t => t.created = new Date(t.created));
 		return self.taskList;
 	};
 

--- a/js/model.js
+++ b/js/model.js
@@ -20,21 +20,22 @@ let Task = function(item, created, status, priority){
 };
 
 let Model = function(){
+	var self = this;
+	this.taskList = new Array();
 
 	this.init = function(){
 		this.db = new Database();
 		this.db.init();
-		this.db.loadAllItems();
+		// this.db.loadAllItems();
 	};
 
-	this.loadAllItems = function(){
-		let loadAllPromise = this.db.loadAllItems(); // returns a promise
-		loadAllPromise
-			.then((results) => { this.updateTodoList(results); })
-			.catch((error) => { console.log("Error in promise " + error.message ); });
-
-		return loadAllPromise;
+	async function loadAllItems(){
+		let results = await this.db.loadAllItems(); // returns a promise
+		self.taskList = Object.values(results.rows);
+		return self.taskList;
 	};
+
+	this.loadAllItems = loadAllItems;
 
 	this.updateTodoList = function(result){
 		this.todoList = [];

--- a/js/model.js
+++ b/js/model.js
@@ -69,7 +69,12 @@ let Model = function(){
 	}	
 	this.clearCompleted = clearCompleted;
 
-	this.clearAll = function(){ return this.db.deleteAll(); }; //returns a promise
+	// Async-ed deleteAll function - reloads taskList after update!!
+	async function clearAll(){
+		await this.db.deleteAll();
+		await this.loadAllItems();
+	}
+	this.clearAll = clearAll;
 
 	// Async-ed updateStatus function - reloads taskList after update
 	async function updateStatus($items, status){

--- a/js/model.js
+++ b/js/model.js
@@ -73,9 +73,15 @@ let Model = function(){
 
 	this.clearAll = function(){ return this.db.deleteAll(); }; //returns a promise
 
-	this.updateStatus = function($item){
-		return this.db.updateStatus($($item).attr('id'), $($item).attr('status')); //returns a promise
-	};
+	// Async-ed updateStatus function - reloads taskList after update
+	async function updateStatus($items, status){
+		//TODO: Error handling in case Promise rejects
+		await Promise.all($items.toArray().map(async function(item) {
+			return self.db.updateStatus($(item).attr('id'), status);
+		}));
+		await self.loadAllItems();
+	}
+	this.updateStatus = updateStatus;
 
 	this.deleteSingleItem = function(item){
 		return this.db.deleteByKey(item);

--- a/js/model.js
+++ b/js/model.js
@@ -132,20 +132,20 @@ let Model = function(){
 	this.Groupers.groupByStatus = function(taskList){
 		let result = {};
 		let groupKeyNames = { 'X' : 'Completed', '' : 'Incomplete'};
-		let groupKeys = new Set(taskList.map(task => task.status));
+		let groupKeys = new Set(taskList['All'].map(task => task.status));
 
-		groupKeys.forEach((gropuKey) => {
-			result[groupKeyNames[groupKeys]] = taskList.filter(task => task.status == groupKey);
+		groupKeys.forEach((groupKey) => {
+			result[groupKeyNames[groupKey]] = taskList['All'].filter(task => task.status == groupKey);
 		});
 		return result;
 	};
 
 	this.Groupers.groupByDate = function(taskList){
 		let result = {};
-		let groupKeys = new Set(taskList.map(task => task.date));
+		let groupKeys = new Set(taskList['All'].map(task => task.created));
 
-		groupKeys.forEach((gropuKey) => {
-			result[groupKeys] = taskList.filter(task => task.created == groupKey);
+		groupKeys.forEach((groupKey) => {
+			result[groupKey] = taskList['All'].filter(task => task.created == groupKey);
 		});
 		return result;
 	};
@@ -153,10 +153,10 @@ let Model = function(){
 	this.Groupers.groupByPriority = function(taskList){
 		let result = {};
 		let groupKeyNames = { '!' : 'High', '-' : 'Medium', '/' : 'Low'};
-		let groupKeys = new Set(taskList.map(task => task.priority));
+		let groupKeys = new Set(taskList['All'].map(task => task.priority));
 
-		groupKeys.forEach((gropuKey) => {
-			result[groupKeyNames[groupKeys]] = taskList.filter(task => task.priority == groupKey);
+		groupKeys.forEach((groupKey) => {
+			result[groupKeyNames[groupKey]] = taskList['All'].filter(task => task.priority == groupKey);
 		});
 		return result;
 	};
@@ -220,9 +220,9 @@ let Model = function(){
 		for(group in taskList){
 			result[group] = taskList[group].sort((t1, t2) => {
 				if(t1.created > t2.created){
-					return -1;
-				}else {
 					return 1;
+				}else {
+					return -1;
 				}
 			});
 		}
@@ -236,9 +236,9 @@ let Model = function(){
 		for(group in taskList){
 			result[group] = taskList[group].sort((t1, t2) => {
 				if(t1.created > t2.created){
-					return 1;
-				}else {
 					return -1;
+				}else {
+					return 1;
 				}
 			});
 		}
@@ -251,7 +251,7 @@ let Model = function(){
 		
 		for(group in taskList){
 			result[group] = taskList[group].sort((t1, t2) => {
-				return self.priorityOrder[t2.priority] - self.priorityOrder[t1.priority];
+				return self.priorityOrder[t1.priority] - self.priorityOrder[t2.priority];
 			});
 		}
 		return result;
@@ -262,7 +262,7 @@ let Model = function(){
 		
 		for(group in taskList){
 			result[group] = taskList[group].sort((t1, t2) => {
-				return self.priorityOrder[t1.priority] - self.priorityOrder[t2.priority];
+				return self.priorityOrder[t2.priority] - self.priorityOrder[t1.priority];
 			});
 		}
 		return result;
@@ -274,7 +274,7 @@ let Model = function(){
 
 		for(group in tasks){
 			result[group] = taskList[group].sort((t1, t2) => {
-				return this.statusOrder[t1.status] - this.statusOrder[t2.status];
+				return this.statusOrder[t2.status] - this.statusOrder[t1.status];
 			});
 		}
 		return result;
@@ -286,7 +286,7 @@ let Model = function(){
 
 		for(group in tasks){
 			result[group] = taskList[group].sort((t1, t2) => {
-				return this.statusOrder[t2.status] - this.statusOrder[t1.status];
+				return this.statusOrder[t1.status] - this.statusOrder[t2.status];
 			});
 		}
 		return result;

--- a/js/model.js
+++ b/js/model.js
@@ -22,6 +22,18 @@ let Task = function(item, created, status, priority){
 let Model = function(){
 	var self = this;
 	this.taskList = new Array();
+	this.Sorters = {};
+
+	this.priorityOrder = {
+		'!' : 99,
+		'-' : 50,
+		'/' : 10
+	};
+
+	this.statusOrder = {
+		'X' : 99,
+		''  : 9
+ 	};
 
 	this.init = function(){
 		this.db = new Database();
@@ -67,5 +79,56 @@ let Model = function(){
 
 	this.deleteSingleItem = function(item){
 		return this.db.deleteByKey(item);
+	};
+
+	this.toTitleCase = function(str){
+		return str.replace(/^[-A-Z]|\s[a-z]/igm, function(m) {return m.toUpperCase()});
+	};
+
+	this.sortedList = function(sortCriteria){
+		let sortFunction = sortCriteria
+								.split('-')
+								.map( str => self.toTitleCase(str))
+								.reduce((final, curr) => { return final + curr; }, 'sort');
+		try{
+			return self.Sorters[sortFunction]();
+		}catch(TypeError){
+			console.log('function ' + sortFunction + '() not defined.  Sorting by Date by defualt');
+			return self.Sorters['sortByDateAsc']();
+		}
+	}
+
+	this.Sorters.sortByDateAsc = function(){
+		console.log("sortByDateAsc");
+		return self.taskList.sort((t1, t2) => {
+			if(t1.created > t2.created){
+				return -1;
+			}else {
+				return 1;
+			}
+		});
+	};
+	this.Sorters.sortByDateDesc = function(){
+		console.log("sortByDateDsc");
+		return self.taskList.sort((t1, t2) => {
+			if(t1.created > t2.created){
+				return 1;
+			}else {
+				return -1;
+			}
+		});
+	};
+	this.Sorters.sortByPriorityAsc = function(){
+		console.log("sortByPriorityAsc");
+		
+		return self.taskList.sort((t1, t2) => {
+			return self.priorityOrder[t2.priority] - self.priorityOrder[t1.priority];
+		});
+	};
+	this.Sorters.sortByPriorityDesc = function(){
+		console.log("sortByPriorityDesc");
+		return self.taskList.sort((t1, t2) => {
+			return self.priorityOrder[t1.priority] - self.priorityOrder[t2.priority];
+		});
 	};
 };

--- a/js/model.js
+++ b/js/model.js
@@ -142,10 +142,10 @@ let Model = function(){
 
 	this.Groupers.groupByDate = function(taskList){
 		let result = {};
-		let groupKeys = new Set(taskList['All'].map(task => task.created));
+		let groupKeys = new Set(taskList['All'].map(task => dateToddMonFormat(task.created)));
 
 		groupKeys.forEach((groupKey) => {
-			result[groupKey] = taskList['All'].filter(task => task.created == groupKey);
+			result[groupKey] = taskList['All'].filter(task => dateToddMonFormat(task.created) == groupKey);
 		});
 		return result;
 	};

--- a/js/model.js
+++ b/js/model.js
@@ -94,7 +94,7 @@ let Model = function(){
 			return self.Sorters[sortFunction]();
 		}catch(TypeError){
 			console.log('function ' + sortFunction + '() not defined.  Sorting by Date by defualt');
-			return self.Sorters['sortByDateAsc']();
+			return self.Sorters['sortByDateDesc']();
 		}
 	}
 
@@ -129,6 +129,18 @@ let Model = function(){
 		console.log("sortByPriorityDesc");
 		return self.taskList.sort((t1, t2) => {
 			return self.priorityOrder[t1.priority] - self.priorityOrder[t2.priority];
+		});
+	};
+	this.Sorters.sortByStatusCompleteFirst = function(){
+		console.log("sortByStatusCompleteFirst");
+		return self.taskList.sort((t1, t2) => {
+			return this.statusOrder[t1.status] - this.statusOrder[t2.status];
+		});
+	};
+	this.Sorters.sortByStatusIncompleteFirst = function(){
+		console.log("sortByStatusIncompleteFirst");
+		return self.taskList.sort((t1, t2) => {
+			return this.statusOrder[t2.status] - this.statusOrder[t1.status];
 		});
 	};
 };

--- a/js/todo-item.js
+++ b/js/todo-item.js
@@ -80,14 +80,20 @@ class TodoItem extends HTMLElement {
 		switch(name){
 			case "created":
 				newVal = this.getDateInFormat(new Date(newVal));
+				this[attrName] = newVal;
 				break;
+			case "status":
+				this[attrName] = newVal;
+				this._updateRendering();
+				break;
+			default:
+				this[attrName] = newVal;
 		}
-		this[attrName] = newVal;
+		
 	}
 
 	connectedCallback(){
 		this._updateRendering();
-		this.shadow.querySelector('li input').addEventListener('click', this._onClick.bind(this));
 	}
 
 	_onClick(event){
@@ -237,6 +243,7 @@ class TodoItem extends HTMLElement {
 		`;
 
 		this.shadow.innerHTML = todo_template;
+		this.shadow.querySelector('li input').addEventListener('click', this._onClick.bind(this));
 		this.dispatchEvent(new CustomEvent('change', {
 			detail : { 
 				checked : false, 

--- a/js/todo-item.js
+++ b/js/todo-item.js
@@ -136,7 +136,7 @@ class TodoItem extends HTMLElement {
 				}
 				:host(.completed) li{
 					text-decoration: line-through;
-					color: #ada3a3;
+					// color: #ada3a3;
 				}
 				:host(.completed:hover) li{
 					background-color: #c6f2d4;
@@ -144,7 +144,7 @@ class TodoItem extends HTMLElement {
 				}
 				:host([status='X']) li{
 					text-decoration: line-through;
-					color: #ada3a3;
+					// color: #ada3a3;
 				}
 				/*:host([status='X']:hover) li{
 					background-color: #c6f2d4;

--- a/js/todo-item.js
+++ b/js/todo-item.js
@@ -5,10 +5,16 @@ class TodoItem extends HTMLElement {
 
 		this.shadow = this.attachShadow({mode : 'open'});
 		this._id = '';
-		this._text = '';
-		this._created = new Date();
+		this._text = '';		
+		let d = new Date();
+		this._created = this.getDateInFormat(d);
 		this._status = '';
 		this._priority = '';
+	}
+
+	getDateInFormat(date){
+		let options = { month : "short", day : "2-digit" };
+		return date.toLocaleDateString("en-IN", options);
 	}
 
 	get id(){
@@ -60,7 +66,8 @@ class TodoItem extends HTMLElement {
 	}
 
 	set created(val){
-		this.setAttribute('created', val);
+		let d = new Date(val);
+		this.setAttribute('created', this.getDateInFormat(d));
 	}
 
 	static get observedAttributes(){
@@ -69,11 +76,13 @@ class TodoItem extends HTMLElement {
 
 	attributeChangedCallback(name, oldVal, newVal){
 		var attrName = '_' + name;
-		this[attrName] = newVal;
-		
-		if(name == 'status'){
-			// this._updateRendering();
+
+		switch(name){
+			case "created":
+				newVal = this.getDateInFormat(new Date(newVal));
+				break;
 		}
+		this[attrName] = newVal;
 	}
 
 	connectedCallback(){
@@ -223,6 +232,7 @@ class TodoItem extends HTMLElement {
 					<span class="checkmark"></span>
 				</label>
 				<div class="col fluid">${this.text}</div>
+				<div class="col">${this.created}</div>
 			</li>
 		`;
 

--- a/js/util.js
+++ b/js/util.js
@@ -1,4 +1,4 @@
 var dateToddMonFormat = function(date){
-	let options = { month : "short", day : "2-digit" };
+	let options = { month : "short", day : "2-digit", year : "numeric"};
 	return date.toLocaleDateString("en-IN", options);
 };

--- a/js/util.js
+++ b/js/util.js
@@ -1,0 +1,4 @@
+var dateToddMonFormat = function(date){
+	let options = { month : "short", day : "2-digit" };
+	return date.toLocaleDateString("en-IN", options);
+};

--- a/js/view.js
+++ b/js/view.js
@@ -49,6 +49,10 @@ let View = function(model){
 			this.filterByTag($thisTag.attr('text'));
 		}.bind(this));
 
+		$('#sort-by').on('change', (event) => {
+			self.renderList(self.model.sortedList($(event.target).val()));
+		});
+
 		//render initial list
 		this.model.loadAllItems().then(this.renderList);
 	};

--- a/js/view.js
+++ b/js/view.js
@@ -28,12 +28,12 @@ let View = function(model){
 		}.bind(this));
 
 		$("#btn-clear-completed").on("click", (e) => {
-			this.controller.clearCompleted()
+			this.model.clearCompleted()
 				.then((results) => { this.renderList(self.model.getList(self.ListDisplayOptions)); })
 				.catch((error) => { console.log("Error in clearCompleted promise: " + error.message); });
 		});
 		$("#btn-clear-all").on("click", (e) => {
-			this.controller.clearAll()
+			this.model.clearAll()
 				.then((results) => { this.renderList(self.model.getList(self.ListDisplayOptions)); })
 				.catch((error) => { console.log("Error in clearAll promise: " + error.message); });
 		});
@@ -118,17 +118,12 @@ let View = function(model){
 
 	this.deleteSelected = function(e){
 		$items = $('todo-item[selected]');
-
-		$.each($items, (function(){
-			return function(i, item){
-				this.model.deleteSingleItem(item)
-					.then((results) => {
-						$(item).remove();
-					})
-					.catch((error) => { console.log('Error in deleteSelected(): ' + error.message); });
-			}.bind(this);
-		}.bind(this))());
-		this.refreshTags();
+		self.model
+			.deleteSingleItem($items)
+			.then((results) => {
+				self.renderList(self.model.getList(self.ListDisplayOptions));
+				self.refreshTags();
+			});
 	};
 
 	this.undoCompletion = function(e){
@@ -136,7 +131,6 @@ let View = function(model){
 		self.model
 			.updateStatus($items, '')
 			.then((results) => {
-				$items.attr('status', '').on('change', self.toggleSelection);
 				self.renderList(self.model.getList(self.ListDisplayOptions));
 				self.refreshTags();
 			});
@@ -147,7 +141,6 @@ let View = function(model){
 		self.model
 			.updateStatus($items, 'X')
 			.then((results) => {
-				$items.attr('status', 'X').on('change', self.toggleSelection);
 				self.renderList(self.model.getList(self.ListDisplayOptions));
 				self.refreshTags();
 			});

--- a/js/view.js
+++ b/js/view.js
@@ -133,7 +133,8 @@ let View = function(model){
 			.then((results) => {
 				self.renderList(self.model.getList(self.ListDisplayOptions));
 				self.refreshTags();
-			});
+			})
+			.catch(console.error);
 	};
 
 	this.undoCompletion = function(e){
@@ -143,7 +144,8 @@ let View = function(model){
 			.then((results) => {
 				self.renderList(self.model.getList(self.ListDisplayOptions));
 				self.refreshTags();
-			});
+			})
+			.catch(console.error);
 	},
 
 	this.completeSelected = function(e){
@@ -153,6 +155,7 @@ let View = function(model){
 			.then((results) => {
 				self.renderList(self.model.getList(self.ListDisplayOptions));
 				self.refreshTags();
-			});
+			})
+			.catch(console.error);
 	};		
 };

--- a/js/view.js
+++ b/js/view.js
@@ -27,20 +27,30 @@ let View = function(model){
 			
 		}.bind(this));
 
-		$("#btn-clear-completed").on("click", (e) => {
-			this.model.clearCompleted()
-				.then((results) => { this.renderList(self.model.getList(self.ListDisplayOptions)); })
-				.catch((error) => { console.log("Error in clearCompleted promise: " + error.message); });
-		});
-		$("#btn-clear-all").on("click", (e) => {
+		$("#btn-clear-completed")
+			.prop('title', 'Delete completed tasks from database')
+			.on("click", (e) => {
+				this.model.clearCompleted()
+					.then((results) => { this.renderList(self.model.getList(self.ListDisplayOptions)); })
+					.catch((error) => { console.log("Error in clearCompleted promise: " + error.message); });
+			});
+		$("#btn-clear-all")
+			.prop('title', 'Delete all tasks from database')
+			.on("click", (e) => {
 			this.model.clearAll()
 				.then((results) => { this.renderList(self.model.getList(self.ListDisplayOptions)); })
 				.catch((error) => { console.log("Error in clearAll promise: " + error.message); });
-		});
+			});
 
-		$('#btn-complete-marked').on('click', this.completeSelected.bind(this));
-		$('#btn-delete-marked').on('click', this.deleteSelected.bind(this));
-		$('#btn-undo-complete').on('click', this.undoCompletion.bind(this));
+		$('#btn-complete-marked')
+			.prop('title', 'Set selected tasks to "Completed" status')
+			.on('click', this.completeSelected.bind(this));
+		$('#btn-delete-marked')
+			.prop('title', 'Delete selected tasks from database')
+			.on('click', this.deleteSelected.bind(this));
+		$('#btn-undo-complete')
+			.prop('title', 'Set selected tasks to "Incomplete" status ')
+			.on('click', this.undoCompletion.bind(this));
 		
 		$('#btn-info').on('click', function(e){
 			$('.info ul').slideToggle();
@@ -96,7 +106,7 @@ let View = function(model){
 		$.each(Object.keys(results), (i, key) => {
 			//for each group, create a new UL list and set the heading to group key
 			let $list = $('<ul>');
-			$($list).append('<h4>' + key + '</h4>');
+			$($list).append('<h5>' + key + '</h5>');
 			$.each(results[key], (j, task) => {
 				$($list)
 					.append($('<todo-item>')

--- a/js/view.js
+++ b/js/view.js
@@ -2,8 +2,8 @@ let View = function(model){
 	var self = this;
 	this.model = model;
 	this.ListDisplayOptions = {
-		'filterCriteria' 	: 'all',
-		'groupCriteria' 	: 'none',
+		'filterCriteria' 	: 'by-all',
+		'groupCriteria' 	: 'by-status',
 		'sortCriteria' 		: 'by-date-desc'
 	};
 		
@@ -58,6 +58,11 @@ let View = function(model){
 			self.ListDisplayOptions['sortCriteria'] = $(event.target).val();
 			self.renderList(self.model.getList(self.ListDisplayOptions));
 		});
+		
+		$('#group-by').on('change', (event) => {
+			self.ListDisplayOptions['groupCriteria'] = $(event.target).val();
+			self.renderList(self.model.getList(self.ListDisplayOptions));
+		});
 
 		//render initial list
 		this.model.loadAllItems().then((results) => this.renderList(self.model.getList(self.ListDisplayOptions)));
@@ -75,7 +80,7 @@ let View = function(model){
 				self.ListDisplayOptions['filterCriteria'] = 'by-all';
 				break;
 		}
-		self.renderList(self.model.getList({'filterCriteria' : self.ListDisplayOptions['filterCriteria']}));
+		self.renderList(self.model.getList(self.ListDisplayOptions));
 	};
 
 	this.refreshTags = function(){
@@ -91,9 +96,10 @@ let View = function(model){
 		$.each(Object.keys(results), (i, key) => {
 			//for each group, create a new UL list and set the heading to group key
 			let $list = $('<ul>');
+			$($list).append('<h4>' + key + '</h4>');
 			$.each(results[key], (j, task) => {
 				$($list)
-					.prepend($('<todo-item>')
+					.append($('<todo-item>')
 						.attr('text', task.item)
 						.attr('id', task.id)
 						.attr('status', task.status)
@@ -103,17 +109,6 @@ let View = function(model){
 			});
 			$('#list-area').append($list);
 		});
-		// $.each(results, (i, task) => {
-		// 	$(self.list)
-		// 		.prepend($('<todo-item>')
-		// 			.attr('text', task.item)
-		// 			.attr('id', task.id)
-		// 			.attr('status', task.status)
-		// 			.attr('priority', task.priority)
-		// 			.attr('created', task.created)
-		// 			.on('change', self.toggleSelection));
-			
-		// });
 		self.refreshTags();
 	};
 
@@ -142,6 +137,7 @@ let View = function(model){
 			.updateStatus($items, '')
 			.then((results) => {
 				$items.attr('status', '').on('change', self.toggleSelection);
+				self.renderList(self.model.getList(self.ListDisplayOptions));
 				self.refreshTags();
 			});
 	},
@@ -152,6 +148,7 @@ let View = function(model){
 			.updateStatus($items, 'X')
 			.then((results) => {
 				$items.attr('status', 'X').on('change', self.toggleSelection);
+				self.renderList(self.model.getList(self.ListDisplayOptions));
 				self.refreshTags();
 			});
 	};		

--- a/js/view.js
+++ b/js/view.js
@@ -13,7 +13,7 @@ let View = function(model){
 			let created = new Date();				
 			let todoItem = new Task(item, created, '', '');
 			
-			this.controller
+			this.model
 				.addItem(todoItem)
 				.then((results) => { 
 					this.renderList(); 
@@ -79,7 +79,7 @@ let View = function(model){
 
 	this.refreshTags = function(tasks){
 		if(!tasks){
-			let tasks = this.model.taskList;
+			tasks = this.model.taskList;
 		}
 		$("#total-items-tag").attr('data', tasks.length);
 		$("#active-items-tag").attr('data', (tasks.filter((item) => item.status == '')).length);
@@ -98,7 +98,7 @@ let View = function(model){
 					.attr('status', task.status)
 					.attr('priority', task.priority)
 					.attr('created', task.created)
-					.on('change', this.toggleSelection));
+					.on('change', self.toggleSelection));
 			
 		});
 		self.refreshTags(results);
@@ -113,7 +113,7 @@ let View = function(model){
 
 		$.each($items, (function(){
 			return function(i, item){
-				this.controller.deleteSingleItem(item)
+				this.model.deleteSingleItem(item)
 					.then((results) => {
 						$(item).remove();
 					})
@@ -124,39 +124,22 @@ let View = function(model){
 	};
 
 	this.undoCompletion = function(e){
-		$completedItems = $('todo-item[selected]').filter('[status="X"]');
-
-		$.each($completedItems, (function(){
-			return function(i, item){
-				$(item).attr('status', '');
-				this.controller.updateStatus($(item))
-					.then((results) => {
-						$removedItem = $(item).remove();
-						$removedItem.on('change', this.toggleSelection.bind(this));					
-						$(this.list).prepend($removedItem);
-					})
-					.catch((error) => { console.log("Error in undoCompletion: "+ error.message); });
-			}.bind(this);
-		}.bind(this))());
-		this.refreshTags(null);
+		$items = $('todo-item[selected]').filter('[status="X"]');
+		self.model
+			.updateStatus($items, '')
+			.then((results) => {
+				$items.attr('status', '').on('change', self.toggleSelection);
+				self.refreshTags(null);
+			});
 	},
 
 	this.completeSelected = function(e){
 		$items = $('todo-item[selected]').filter('[status=""]');
-		
-		$.each($items, (function(){
-			return function(i, item){
-				$(item).attr('status', 'X')
-				this.model
-					.updateStatus($(item))
-					.then((results) => {
-						$removedItem = $(item).remove();
-						$removedItem.on('change', this.toggleSelection.bind(this));					
-						$(this.completedList).prepend($removedItem);
-					})
-					.catch((error) => { console.log("Error in updateStatus Promise: " + error.message); });
-			}.bind(this);
-		}.bind(this))());
-		this.refreshTags(null);
+		self.model
+			.updateStatus($items, 'X')
+			.then((results) => {
+				$items.attr('status', 'X').on('change', self.toggleSelection);
+				self.refreshTags(null);
+			});
 	};		
 };

--- a/js/view.js
+++ b/js/view.js
@@ -147,7 +147,7 @@ let View = function(model){
 		$.each($items, (function(){
 			return function(i, item){
 				$(item).attr('status', 'X')
-				this.controller
+				this.model
 					.updateStatus($(item))
 					.then((results) => {
 						$removedItem = $(item).remove();


### PR DESCRIPTION
These functionalities / changes are added in this pull request:

- Sorting by date (latest first, oldest first, priority high to low, priority low to high)
- Grouping by - status, date, priority and no grouping
- All `database` calls from `model `are converted to `async-await`
- Every database related transaction now causes re-rendering of the list
- Better `renderList()` method in `view`
- Display `created_date` on list item for better planning option - format used for this is locale "en-IN" with 3 digit month and 2-digit date i.e. 18 August 2018 will be displayed as "18 Aug".  Year is not displayed because, this TODO list is not meant for a very long term planning!

**A Note on Grouping and Sorting**

It is a bit tricky topic - because, should the sorting be intra-group or inter-group.  For example, 
- if sorting is based on "date" and grouping is also on "date", then should the groups be sorted or items inside each group be sorted or both?
- if sorting is based on "priority" but grouping is on "date", then it is not clear or there is no meaningful way to show the groups themselves in any order

Therefore, to keep things simple, approach used is - sorting is always done intra-group i.e. items inside each group are sorted by the selected sort order.  No guaranty on the order of the displayed group.  But, based on testing, if both sorting and grouping are on same parameter, then result is better.